### PR TITLE
ASoC: codec: max98373: Removed superfluous volume control from chip d…

### DIFF
--- a/sound/soc/codecs/max98373.c
+++ b/sound/soc/codecs/max98373.c
@@ -780,13 +780,6 @@ static int max98373_probe(struct snd_soc_component *component)
 	regmap_write(max98373->regmap,
 		MAX98373_R202A_PCM_TO_SPK_MONO_MIX_2,
 		0x1);
-	/* Set inital volume (0dB) */
-	regmap_write(max98373->regmap,
-		MAX98373_R203D_AMP_DIG_VOL_CTRL,
-		0x00);
-	regmap_write(max98373->regmap,
-		MAX98373_R203E_AMP_PATH_GAIN,
-		0x00);
 	/* Enable DC blocker */
 	regmap_write(max98373->regmap,
 		MAX98373_R203F_AMP_DSP_CFG,

--- a/sound/soc/codecs/max98373.h
+++ b/sound/soc/codecs/max98373.h
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0
-// Copyright (c) 2017, Maxim Integrated
+/* SPDX-License-Identifier: GPL-2.0-only
+ *  Copyright (c) 2017 Maxim Integrated
+ */
 
 #ifndef _MAX98373_H
 #define _MAX98373_H
@@ -220,8 +221,8 @@ struct max98373_priv {
 	unsigned int rx_mask;
 };
 
-extern const struct snd_soc_component_driver soc_codec_dev_max98373_sdw;
-extern void max98373_reset(struct max98373_priv *max98373, struct device *dev);
-extern void max98373_slot_config(struct device *dev,
-	struct max98373_priv *max98373);
+const struct snd_soc_component_driver soc_codec_dev_max98373_sdw;
+void max98373_reset(struct max98373_priv *max98373, struct device *dev);
+void max98373_slot_config(struct device *dev,
+			  struct max98373_priv *max98373);
 #endif


### PR DESCRIPTION
…efault

Removed superfluous volume control from chip default.
Modified SPDX-License header.
Removed extern from the header.

Signed-off-by: Ryan Lee <ryans.lee@maximintegrated.com>